### PR TITLE
Fix/ignore message menu links and selection

### DIFF
--- a/src/platforms/kick/modules/settings/settings.module.tsx
+++ b/src/platforms/kick/modules/settings/settings.module.tsx
@@ -116,13 +116,13 @@ export default class SettingsModule extends KickModule {
 				type: "toggle",
 				tabIndex: 1,
 			},
-			{
-				id: "chatMessageMenuEnabled",
-				title: "Enable Chat Message Menu",
-				description: "Show a menu with message options when you right-click a chat message.",
-				type: "toggle",
-				tabIndex: 1,
-			},
+			// {
+			// 	id: "chatMessageMenuEnabled",
+			// 	title: "Enable Chat Message Menu",
+			// 	description: "Show a menu with message options when you right-click a chat message.",
+			// 	type: "toggle",
+			// 	tabIndex: 1,
+			// },
 			{
 				id: "quickAccessLinks",
 				title: "Quick Access Links",

--- a/src/platforms/twitch/modules/chat-message-menu/chat-message-menu.module.tsx
+++ b/src/platforms/twitch/modules/chat-message-menu/chat-message-menu.module.tsx
@@ -17,16 +17,20 @@ export default class ChatMessageMenuModule extends TwitchModule {
 		isModuleEnabledCallback: () => this.settingsService().getSettingsKey("chatMessageMenuEnabled"),
 	};
 
-	private async handleMessage({ message, element }: TwitchChatMessageEvent) {
+	private static readonly BLOCKED_TAGS = ["a", "img"];
+
+	private async handleMessage({ message, element: _element }: TwitchChatMessageEvent) {
 		if (!(await this.isModuleEnabled())) return;
-		(element as HTMLElement).addEventListener("contextmenu", async (e) => {
+		const element = _element as HTMLElement;
+		element.addEventListener("contextmenu", async (event) => {
 			if (window.getSelection()?.toString()) return;
-			if ((e.target as HTMLElement)?.closest("a")) return;
-			e.preventDefault();
+			const tag = (event.target as HTMLElement | null)?.tagName.toLowerCase();
+			if (ChatMessageMenuModule.BLOCKED_TAGS.includes(tag || "")) return;
+			event.preventDefault();
 			this.emitter.emit("twitch:messageMenu", {
 				options: this.getOptions(message),
-				x: e.x,
-				y: e.y,
+				x: event.x,
+				y: event.y,
 			});
 		});
 	}

--- a/src/platforms/twitch/modules/chat-message-menu/chat-message-menu.module.tsx
+++ b/src/platforms/twitch/modules/chat-message-menu/chat-message-menu.module.tsx
@@ -19,7 +19,9 @@ export default class ChatMessageMenuModule extends TwitchModule {
 
 	private async handleMessage({ message, element }: TwitchChatMessageEvent) {
 		if (!(await this.isModuleEnabled())) return;
-		(element as HTMLElement).addEventListener("contextmenu", (e) => {
+		(element as HTMLElement).addEventListener("contextmenu", async (e) => {
+			if (window.getSelection()?.toString()) return;
+			if ((e.target as HTMLElement)?.closest("a")) return;
 			e.preventDefault();
 			this.emitter.emit("twitch:messageMenu", {
 				options: this.getOptions(message),


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR fixes the handling of message menu links and their selection in the chat message menu module.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant ChatMessage
    participant ChatMessageMenuModule
    participant EventEmitter

    User->>ChatMessage: Right clicks message
    Note over ChatMessage: Check if text is selected
    Note over ChatMessage: Check if clicked element is not blocked (a, img)
    
    ChatMessage->>ChatMessageMenuModule: Trigger contextmenu event
    ChatMessageMenuModule->>EventEmitter: Emit "twitch:messageMenu"
    Note over EventEmitter: Send menu options with<br/>cursor coordinates (x,y)
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/enhancer-app/enhancer/pull/69/files#diff-da24856b3200d469a2784009679ab07bfd830d2dd3582e42a7b7bc4c822196e7>src/platforms/kick/modules/settings/settings.module.tsx</a></td><td>Commented out the chat message menu settings to disable the feature.</td></tr>
<tr><td><a href=https://github.com/enhancer-app/enhancer/pull/69/files#diff-c20e33d3650d51d54fc912ecb67278cf133afb61e42e1c66fd2ff0b7bbf61e84>src/platforms/twitch/modules/chat-message-menu/chat-message-menu.module.tsx</a></td><td>Updated the message handling to prevent context menu from appearing on certain tags and fixed event handling.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->




