### PR TITLE
fix: set order for all of the extensions icon

### DIFF
--- a/src/platforms/twitch/modules/settings-button/settings-button.module.tsx
+++ b/src/platforms/twitch/modules/settings-button/settings-button.module.tsx
@@ -15,15 +15,27 @@ export default class SettingsButtonModule extends TwitchModule {
 				key: "settings-button-main",
 				once: true,
 			},
-			// {
-			// 	type: "selector",
-			// 	selectors: [".stream-chat-header"],
-			// 	callback: this.run.bind(this),
-			// 	key: "settings-button-chat",
-			// 	validateUrl: (url) => url.includes("/popout/"),
-			// 	once: true,
-			// },
+			{
+				type: "selector",
+				selectors: [".top-nav__menu .ffz-top-nav"],
+				callback: this.setProperOrder.bind(this),
+				key: "ffz_icon",
+				once: true,
+			},
+			{
+				type: "selector",
+				selectors: [".top-nav__menu #seventv-settings-button"],
+				callback: this.setProperOrder.bind(this),
+				key: "7TV_ICON",
+				once: true,
+			},
 		],
+	};
+
+	private static readonly ICONS_ORDER_MAP: Record<string, string> = {
+		ENHANCER_ICON: "-5",
+		FFZ_ICON: "-4",
+		"7TV_ICON": "-3",
 	};
 
 	private async run(elements: Element[], key: string) {
@@ -35,13 +47,20 @@ export default class SettingsButtonModule extends TwitchModule {
 		const wrappers = this.commonUtils().createEmptyElements(this.getId(), properElements, "span");
 		const logo = await this.commonUtils().getIcon(this.workerService(), "enhancer/logo-gray.svg");
 		wrappers.forEach((element) => {
-			element.style.order = "-1";
+			element.style.order = SettingsButtonModule.ICONS_ORDER_MAP.ENHANCER_ICON;
 			render(
 				<TooltipComponent content={<p>Open Enhancer Settings</p>} position="bottom">
 					<SettingsButtonComponent onClick={this.openSettings.bind(this)} logoUrl={logo} />
 				</TooltipComponent>,
 				element,
 			);
+		});
+	}
+
+	private setProperOrder(elements: Element[], key: string) {
+		const order = SettingsButtonModule.ICONS_ORDER_MAP[key.toUpperCase()] ?? -1;
+		elements.forEach((element) => {
+			(element as HTMLElement).style.order = order.toString();
 		});
 	}
 


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR fixes the order of extension icons in the Twitch settings button module by adding a new mapping for icon orders and updating the relevant callback functions.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant TwitchUI as Twitch UI
    participant SettingsModule as Settings Button Module
    participant DOM as DOM Elements

    Note over TwitchUI,DOM: Button Order Management

    TwitchUI->>SettingsModule: Initialize module
    
    par Process Multiple Buttons
        SettingsModule->>DOM: Find Enhancer button
        SettingsModule->>DOM: Set order=-5
        and
        SettingsModule->>DOM: Find FFZ button
        SettingsModule->>DOM: Set order=-4
        and
        SettingsModule->>DOM: Find 7TV button
        SettingsModule->>DOM: Set order=-3
    end

    Note over SettingsModule,DOM: Buttons are now ordered:<br/>Enhancer → FFZ → 7TV

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/enhancer-app/enhancer/pull/71/files#diff-b9cbb03b805b311f40d5ee985532e4b980b0732fb1bb83f1ff3323377ae2aa08>src/platforms/twitch/modules/settings-button/settings-button.module.tsx</a></td><td>Updated the settings button module to include a new order for extension icons and added a method to set the proper order.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


