### PR TITLE
fix: chat attahcments not works with ffz rich embed

### DIFF
--- a/src/platforms/twitch/modules/chat-attachments/chat-attachments.module.ts
+++ b/src/platforms/twitch/modules/chat-attachments/chat-attachments.module.ts
@@ -23,6 +23,8 @@ export default class ChatAttachmentsModule extends TwitchModule {
 	private previousInputContent = "";
 	private inputMonitoringInterval: NodeJS.Timeout | undefined;
 
+	static readonly FFZ_RICH_EMBED_CLASS = ".ffz-card-rich";
+
 	config: TwitchModuleConfig = {
 		name: "chat-attachments",
 		appliers: [
@@ -60,6 +62,10 @@ export default class ChatAttachmentsModule extends TwitchModule {
 
 	private async handleMessage(message: TwitchChatMessageEvent) {
 		if (!(await this.isModuleEnabled())) return;
+
+		await this.commonUtils().delay(1); // Doing this for FFZ Rich Embed Check
+		if (message.element.querySelector(ChatAttachmentsModule.FFZ_RICH_EMBED_CLASS)) return;
+
 		const baseData = this.getBaseData(message);
 		if (!baseData) return;
 		try {


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR fixes the issue with chat attachments not working with FFZ rich embed by adding a class check for FFZ rich embeds.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant CM as Chat Message
    participant CAM as ChatAttachmentsModule
    participant Utils as CommonUtils

    CM->>CAM: handleMessage(message)
    CAM->>CAM: isModuleEnabled()
    CAM->>Utils: delay(1ms)
    Note over CAM: Wait for FFZ embed to load
    CAM->>CM: querySelector(FFZ_RICH_EMBED_CLASS)
    alt FFZ Rich Embed exists
        CAM-->>CM: Return early
    else No FFZ Rich Embed
        CAM->>CAM: getBaseData(message)
        CAM->>CM: Continue processing
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/enhancer-app/enhancer/pull/78/files#diff-0b13b17c32b90a5f03dcc2fca65a84078e431b1f9a11bdbdcc97388ccef876a1>src/platforms/twitch/modules/chat-attachments/chat-attachments.module.ts</a></td><td>Added a static class for FFZ rich embed and implemented a check in the message handling function.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


