### PR TITLE
fix: disable counting watchtime when vod on channel page is playing

### DIFF
--- a/src/platforms/twitch/modules/local-watchtime-counter/local-watchtime-counter.module.tsx
+++ b/src/platforms/twitch/modules/local-watchtime-counter/local-watchtime-counter.module.tsx
@@ -32,12 +32,22 @@ export default class LocalWatchtimeCounterModule extends TwitchModule {
 			const channelName = this.twitchUtils().getCurrentChannelByUrl()?.toLowerCase();
 			if (!channelName) return;
 			const mediaPlayerInstance = this.twitchUtils().getMediaPlayerInstance();
+			if (!this.isLive()) return;
 			if (mediaPlayerInstance && !mediaPlayerInstance.core.paused) {
+				this.logger.debug(`Adding watchtime for ${channelName}`);
 				await this.workerService().send("addWatchtime", {
 					platform: "twitch",
 					channel: channelName,
 				});
 			}
 		}, 5000);
+	}
+
+	private isLive(): boolean {
+		const currentLiveStatus = this.twitchUtils().getCurrentLiveStatus();
+		if (!currentLiveStatus) {
+			return false;
+		}
+		return !currentLiveStatus.isOffline && currentLiveStatus.isLive;
 	}
 }


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR disables counting watchtime when a VOD on the channel page is playing by adding a check for the live status.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant LC as LocalWatchtimeCounter
    participant TU as TwitchUtils
    participant WS as WorkerService

    LC->>TU: getCurrentChannelByUrl()
    alt channel exists
        LC->>TU: getMediaPlayerInstance()
        LC->>TU: isLive()
        alt is live stream
            LC->>TU: getCurrentLiveStatus()
            alt stream is live & not offline
                LC->>WS: send("addWatchtime")
            end
        end
    end

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/enhancer-app/enhancer/pull/88/files#diff-5e09144b3480d1bf9e371006b5bcded4449038994d3222350f583bd716887fee>src/platforms/twitch/modules/local-watchtime-counter/local-watchtime-counter.module.tsx</a></td><td>Added a check to ensure watchtime is only counted when the stream is live.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


